### PR TITLE
fix: Remove hardcoded email and configure secrets scanning for Netlify

### DIFF
--- a/Portfolio/netlify.toml
+++ b/Portfolio/netlify.toml
@@ -7,6 +7,7 @@
 
 [build.environment]
   NODE_VERSION = "18"
+  SECRETS_SCAN_OMIT_PATHS = "DOMAIN_DEPLOYMENT.md,SENDGRID_SETUP.md,EMAIL_SETUP.md"
 
 [[redirects]]
   from = "/*"

--- a/Portfolio/src/pages/api/send-email.js
+++ b/Portfolio/src/pages/api/send-email.js
@@ -18,7 +18,7 @@ export default async function handler(req, res) {
     sgMail.setApiKey(process.env.SENDGRID_API_KEY);
 
     const msg = {
-      to: 'connect@simarjeetsinghjohar.com', // Your email
+      to: process.env.SENDGRID_VERIFIED_SENDER, // Your email (where you receive messages)
       from: process.env.SENDGRID_VERIFIED_SENDER, // Must be verified in SendGrid
       replyTo: email,
       subject: `Portfolio Contact: ${subject}`,


### PR DESCRIPTION
- Replace hardcoded email with environment variable in send-email API
- Add SECRETS_SCAN_OMIT_PATHS to exclude documentation files
- Email now uses SENDGRID_VERIFIED_SENDER from environment variables